### PR TITLE
modification on preprocess

### DIFF
--- a/CodeFormatter.m
+++ b/CodeFormatter.m
@@ -80,17 +80,20 @@ $useSpacesForTabs = True;
 $overallTab = 4;
 
 
+$inlSymbol = "\[IndentingNewLine]";
 
 ClearAll[preprocess];
 preprocess[boxes_] :=
-    boxes //.
-      {RowBox[{("\t" | "\n") .., expr___}] :> expr} //.
-     {
-		s_String /; StringMatchQ[s, Whitespace|""] :> Sequence[],
-        RowBox[{r_RowBox}] :> r,
-	RowBox[{}]:>Sequence[],
-	RowBox[{"Association", "[",inner__,"]"}]:> RowBox[{"<|",inner,"|>"}]
-     };
+      boxes //.
+                RowBox[{("\t" | "\n") .., expr___}]                            :> expr /.
+                timesBox : RowBox[{_, e_String /; StringMatchQ[e, " " ..], _}] :> ReplacePart[timesBox, {1, 2} -> "$TimesMark$"] /.
+                s_String /; StringMatchQ[s, (Whitespace | $inlSymbol | "") ..] :> Sequence[] /.
+                "$TimesMark$"                                                  -> " " //.
+                {
+                 RowBox[{r_RowBox}]                                            :> r,
+                 RowBox[{}]                                                    :> Sequence[],
+                 RowBox[{"Association", "[", inner__, "]"}]                    :> RowBox[{"<|", inner, "|>"}]
+                };
 
 
 ClearAll[$blocks, blockQ];


### PR DESCRIPTION
Modified `preprocess` so it can handle this case:

```
cellbox = 
  RowBox[{RowBox[{"gcd", "[", RowBox[{"m0_", ",", "n0_"}], "]"}], 
    ":=", "\[IndentingNewLine]", 
    RowBox[{"Module", "[", 
      RowBox[{RowBox[{"{", 
          RowBox[{RowBox[{"m", "=", "m0"}], ",", 
            RowBox[{"n", "=", "n0"}]}], "}"}], ",", 
        "\[IndentingNewLine]", 
        RowBox[{RowBox[{"While", "[", 
            RowBox[{RowBox[{"n", "\[NotEqual]", "0"}], ",", 
              RowBox[{RowBox[{"{", RowBox[{"m", ",", "n"}], "}"}], 
                "=", "     ", 
                RowBox[{"{", 
                  RowBox[{"n", ",", 
                    RowBox[{"Mod", "[", 
                    RowBox[{"m", ",", "      ", "n"}], "]"}]}], 
                  "}"}]}]}], "]"}], ";", "\[IndentingNewLine]", 
          RowBox[{RowBox[{"m", " ", "n"}], "+", 
            RowBox[{"2", " ", "3"}], "+", 
            RowBox[{"4", "     ", "5"}]}]}]}], "\[IndentingNewLine]", 
      "]"}]}];
FullCodeFormat[cellbox] // CellPrint[Cell[BoxData[#], "Input"]] &
```

![image](https://cloud.githubusercontent.com/assets/2263328/3949658/0c6ded9a-26ba-11e4-8051-753d20b4ceae.png)
